### PR TITLE
Xcode 10 compatibility

### DIFF
--- a/IncrementableLabel.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/IncrementableLabel.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/IncrementableLabel.swift
+++ b/Source/IncrementableLabel.swift
@@ -143,7 +143,7 @@ extension IncrementableLabel {
         } else if let attributedTextClosure = attributedTextFormatter {
             attributedText = attributedTextClosure(currentValue)
         } else {
-            let formatRange = Range<String.Index>(format.startIndex..<format.endIndex)
+            let formatRange = format.startIndex..<format.endIndex
             if format.range(of: "%(.*)(d|i)", options: .regularExpression, range: formatRange) == formatRange {
                 text = String(format: format, Int(currentValue))
             } else {


### PR DESCRIPTION
I replaced the old `formatRange` initializer inside `updateText` with the simpler range literal to make this library compatible with Xcode 10 & Swift 4.2.